### PR TITLE
Allow apostrophes in local part of email addresses

### DIFF
--- a/lib/validators/constants.rb
+++ b/lib/validators/constants.rb
@@ -1,5 +1,5 @@
 module Validators
-  EMAIL_FORMAT = /\A[a-z0-9]+([-._][a-z0-9]+)*(\+[^@]+)?@[a-z0-9]+([.-][a-z0-9]+)*\.[a-z]{2,4}\z/i
+  EMAIL_FORMAT = /\A[a-z0-9]+([-._'][a-z0-9]+)*(\+[^@]+)?@[a-z0-9]+([.-][a-z0-9]+)*\.[a-z]{2,4}\z/i
 
   # Source: https://github.com/henrik/validates_url_format_of
   IPv4_PART = /\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]/  # 0-255

--- a/spec/support/emails.rb
+++ b/spec/support/emails.rb
@@ -22,7 +22,8 @@ INVALID_EMAILS = [
   'Fred\ Bloggs_@example.com',
   'Abc\@def+@example.com',
   'Joe.\\Blow@example.com',
-  "invalid@invalid.invalid"
+  "invalid@invalid.invalid",
+  "invalid@some'domain.com",
 ]
 
 VALID_EMAILS = [
@@ -38,4 +39,5 @@ VALID_EMAILS = [
   'valid123.456@somedomain.org',
   'valid@somedomain.mobi',
   'valid@somedomain.info',
+  "valido'valid@somedomain.com",
 ]


### PR DESCRIPTION
After using this gem in production successfully we had a real user with
a valid email address that contained an apostrophe in the local part of
the email address. It was in the form
`first_name.o'last_name@domain.com` and this user was unable to be
added to the application due to the email validation. After some
investigation it appears that an apostrophe is a valid character in the
local part (part before the @ symbol).

See https://en.wikipedia.org/wiki/Email_address#Local_part for details.

There are other special characters listed here that are currently not
allowed by the validation but for now I decided just to add the
characters that we need.

I've added email addresses to the valid and invalid lists used by the
specs to ensure that apostrophes are only valid in the local part.