### PR TITLE
Accepts email with consecutive dashes/underlines as they are valid in many services

### DIFF
--- a/lib/validators/constants.rb
+++ b/lib/validators/constants.rb
@@ -1,5 +1,5 @@
 module Validators
-  EMAIL_FORMAT = /\A[a-z0-9]+([-._][a-z0-9]+)*(\+[^@]+)?@[a-z0-9]+([.-][a-z0-9]+)*\.[a-z]{2,}\z/i
+  EMAIL_FORMAT = /\A[-_a-z0-9]+([.][-_a-z0-9]+)*(\+[^@]+)?@[a-z0-9]+([.-][a-z0-9]+)*\.[a-z]{2,}\z/i
   MICROSOFT_EMAIL_FORMAT = /\A[\w][\w\d._-]*[\w\d_-]+(\+[\w\d]+)?@(hotmail|outlook).com\z/i
 
   # Source: https://github.com/henrik/validates_url_format_of

--- a/test/support/emails.rb
+++ b/test/support/emails.rb
@@ -47,4 +47,8 @@ VALID_EMAILS = [
   "valid_-_-_-_-_-_@outlook.com",
   "sub_total-5+8@hotmail.com",
   "sub_total-5+8@outlook.com",
+  "valid__email@somedomain.com",
+  "valid-_-email@somedomain.com",
+  "validemail_@somedomain.com",
+  "valid-email-@somedomain.com",
 ]


### PR DESCRIPTION
I was facing an issue recently from users who use emails containing consecutive underlines and dashes as in `foo__bar@foo.com` or `foo-_-bar@doo.com` I have changed the regex and removed the `-_` chars from the first group and added them as valid chars together with `[a-z0-9]`.

So I did this change to my email_format regex and I was considering is it interesting or do you think that this will validate some invalid emails?

(another issue not subject of this PR although this would also solve them are Microsoft emails that ends in live.com)