### PR TITLE
Don't allow disposable email subdomain

### DIFF
--- a/lib/validators/validates_email_format_of.rb
+++ b/lib/validators/validates_email_format_of.rb
@@ -44,7 +44,9 @@ module ActiveModel
       def validate_disposable_email(record, attribute, value, _options)
         hostname = value.to_s.split(AT_SIGN).last.to_s.downcase
 
-        return unless Validators::DisposableHostnames.all.include?(hostname)
+        return if Validators::DisposableHostnames.all.none? do |disposable_hostname|
+          hostname == disposable_hostname || hostname.end_with?(".#{disposable_hostname}")
+        end
 
         record.errors.add(
           attribute,

--- a/test/validators/disposable_email_test.rb
+++ b/test/validators/disposable_email_test.rb
@@ -14,6 +14,17 @@ class DisposableEmailTest < Minitest::Test
     end
   end
 
+  DISPOSABLE_EMAILS.each do |domain|
+    test "rejects disposable e-mail with subdomain (custom.#{domain})" do
+      User.validates_email_format_of :email
+
+      user = User.new(email: "user@custom.#{domain}")
+      user.valid?
+
+      assert_includes user.errors[:email], I18n.t("activerecord.errors.messages.disposable_email")
+    end
+  end
+
   test "accepts disposable e-mail" do
     User.validates_email_format_of :email, disposable: true
 


### PR DESCRIPTION
Some disposable emails services allow subdomains to escape this kind of verification. With this update, user@tmp123.disposable-mail.com will not be allowed, for example.